### PR TITLE
Refactor to get Column Sorting working

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor
@@ -29,9 +29,9 @@
               <th class="radio"></th>
             }
             @foreach(var column in description.TableProperties) {
-              var direction = SortAscending ? "ascending" : "descending";
-              var sortClasses = column.Property.Name == Sort ? $"sort {direction}" : "";
-              <th class="@column.DisplayClass @sortClasses" @onclick="@(async e => await SortBy(column))">
+                    var direction = QueryBuilder.Sort.Ascending ? "ascending" : "descending";
+                    var sortClasses = column.Property.Name == QueryBuilder.Sort.SortProperty ? $"sort {direction}" : "";
+              <th class="@column.DisplayClass @sortClasses" @onclick="@(e => SortBy(column))">
                 <span>@column.ColumnCaption</span>
                 <sup class="@sortClasses"></sup>
               </th>

--- a/ExtraDry/ExtraDry.Blazor/Components/DryPageQueryView.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/DryPageQueryView.razor
@@ -18,6 +18,6 @@
     /// themselves to changes using a two-way binding.
     /// </summary>
     [CascadingParameter]
-    internal QueryBuilder PageQueryBuilder { get; set; } = new();
+    public QueryBuilder PageQueryBuilder { get; set; } = new();
 
 }


### PR DESCRIPTION
`QueryBuilder.Sort` wasn't being set to enable sorting.
Refactored `DryTable` to remove the Sort fields and use `QueryBuilder.Sort` instead.

Addressed an infinite loop but during the `SortBy` function which enabled the sorted list to be properly refreshed

Made `DryPageQueryView.PageQueryBuilder` public to allow pages to set an initial sort