### PR TITLE
Move HierarchyIdConverter into ExtraDry.Core

### DIFF
--- a/ExtraDry/ExtraDry.Core/Core/HierarchyIdConverter.cs
+++ b/ExtraDry/ExtraDry.Core/Core/HierarchyIdConverter.cs
@@ -1,8 +1,13 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
 
-namespace Sample.Shared;
+namespace ExtraDry.Core;
 
-public class HierarchyIdConverter : JsonConverter<HierarchyId> {
+/// <summary>
+/// A JSON converter that will serialize a HierarchyId object so that it can be deserialised and used on the front end
+/// </summary>
+public class HierarchyIdConverter : JsonConverter<HierarchyId>
+{
     public override HierarchyId? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return HierarchyId.Parse(reader.GetString());


### PR DESCRIPTION
The issue found with the Hierarchy list not expanding or collapsing was due to the Hierarchy not properly being used on the client side to determine the group depth.

The ExtraDry sample uses the `HierarchyIdConverter` but this was in Sample.Server. It is now moved into ExtraDry.Core so it can be used by all usages of the HierarchyList