### PR TITLE
Hierarchy list MinLevel

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryTable.razor.cs
@@ -234,6 +234,7 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
                 var count = container.ItemInfos.Count;
                 var total = container.Total;
                 QueryBuilder.Level.UpdateMaxLevel(ItemsService.MaxLevel);
+                QueryBuilder.Level.UpdateMinLevel(ItemsService.MinLevel);
 
                 InternalItems.AddRange(container.ItemInfos);
                 InternalItems.AddRange(Enumerable.Range(0, total - count).Select(e => new ListItemInfo<TItem>()));
@@ -259,6 +260,7 @@ public partial class DryTable<TItem> : ComponentBase, IDisposable, IExtraDryComp
                         var count = container.ItemInfos.Count;
                         var total = container.Total;
                         QueryBuilder.Level.UpdateMaxLevel(ItemsService.MaxLevel);
+                        QueryBuilder.Level.UpdateMinLevel(ItemsService.MinLevel);
                         var index = firstIndex;
                         foreach(var item in container.ItemInfos) {
                             var info = InternalItems[index++];

--- a/ExtraDry/ExtraDry.Blazor/Internal/Builders/LevelBuilder.cs
+++ b/ExtraDry/ExtraDry.Blazor/Internal/Builders/LevelBuilder.cs
@@ -19,6 +19,12 @@ public class LevelBuilder
     public int MaxLevel { get; private set; }
 
     /// <summary>
+    /// If known, the minimum level of the hierarchy for the collection, ignoring any Level filter 
+    /// that may be applied.
+    /// </summary>
+    public int MinLevel { get; private set; }
+
+    /// <summary>
     /// When collections are returned, the max level might be updated down because of an explicit
     /// level.  Keep the information on the max level exclusive of the level filter.
     /// </summary>
@@ -26,6 +32,17 @@ public class LevelBuilder
     {
         if(MaxLevel == 0 || maxLevel == 0 || maxLevel > MaxLevel) {
             MaxLevel = maxLevel;
+        }
+    }
+
+    /// <summary>
+    /// When collections are returned, the min level might be updated up because of an explicit
+    /// level.  Keep the information on the min level exclusive of the level filter.
+    /// </summary>
+    public void UpdateMinLevel(int minLevel)
+    {
+        if(MinLevel == 0 || minLevel == 0 || minLevel > MinLevel) {
+            MinLevel = minLevel;
         }
     }
 
@@ -50,12 +67,15 @@ public class LevelBuilder
     public bool Collapse()
     {
         var lastLevel = Level;
-        Level = (Level, MaxLevel) switch {
-            (0, 0) => 0,
-            (0, _) => MaxLevel - 1,
-            (_, 0) => Level - 1,
-            (_, _) => Math.Max(Level - 1, 1),
+        Level = (Level, MaxLevel, MinLevel) switch {
+            (0, 0, _) => 0,
+            (0, _, _) => MaxLevel - 1,
+            (_, 0, 0) => Level - 1,
+            (_, 0, _) => Math.Max(Level - 1, MinLevel),
+            (_, _, 0) => Math.Max(Level - 1, 1),
+            (_, _, _) => Math.Max(Level - 1, MinLevel),
         };
+
         return lastLevel != Level;
     }
 

--- a/ExtraDry/ExtraDry.Blazor/ViewModels/IListService.cs
+++ b/ExtraDry/ExtraDry.Blazor/ViewModels/IListService.cs
@@ -8,6 +8,8 @@ public interface IListService<T> : IOptionProvider<T> {
 
     int MaxLevel { get; }
 
+    int MinLevel { get; }
+
     ValueTask<ItemsProviderResult<T>> GetItemsAsync(Query query, CancellationToken cancellationToken = default);
 
     ValueTask<ListItemsProviderResult<T>> GetListItemsAsync(Query query, CancellationToken cancellationToken = default);

--- a/ExtraDry/ExtraDry.Blazor/ViewModels/ListService.cs
+++ b/ExtraDry/ExtraDry.Blazor/ViewModels/ListService.cs
@@ -51,11 +51,13 @@ public class ListService<TItem> : IListService<TItem> {
                 HierarchyUnpacker = e => (e as PagedHierarchyCollection<TItem>)?.Items ?? new Collection<TItem>();
                 HierarchyCounter = e => (e as PagedHierarchyCollection<TItem>)?.Total ?? 0;
                 HierarchyMaxLevel = e => (e as PagedHierarchyCollection<TItem>)?.MaxLevels ?? 0;
+                HierarchyMinLevel = e => (e as PagedHierarchyCollection<TItem>)?.MinLevels ?? 0;
             }
             else if(options.HierarchyMode == HierarchyServiceMode.Filter) {
                 HierarchyUnpacker = e => (e as HierarchyCollection<TItem>)?.Items ?? new Collection<TItem>();
                 HierarchyCounter = e => (e as HierarchyCollection<TItem>)?.Count ?? 0;
                 HierarchyMaxLevel = e => (e as HierarchyCollection<TItem>)?.MaxLevels ?? 0;
+                HierarchyMinLevel = e => (e as PagedHierarchyCollection<TItem>)?.MinLevels ?? 0;
             }
         }
     }
@@ -78,7 +80,11 @@ public class ListService<TItem> : IListService<TItem> {
 
     private Func<object, int>? HierarchyMaxLevel { get; set; }
 
+    private Func<object, int>? HierarchyMinLevel { get; set; }
+
     public int MaxLevel { get; private set; }
+
+    public int MinLevel { get; private set; }
 
     public JsonSerializerOptions JsonSerializerOptions { get; set; }
 
@@ -205,6 +211,7 @@ public class ListService<TItem> : IListService<TItem> {
             var items = HierarchyUnpacker!(packedResult);
             var total = HierarchyCounter!(packedResult);
             MaxLevel = HierarchyMaxLevel!(packedResult);
+            MinLevel = HierarchyMinLevel!(packedResult);
             return (packedResult, items, total);
         }
         else {

--- a/ExtraDry/ExtraDry.Core/FilterSortPage/Collections/HierarchyCollection.cs
+++ b/ExtraDry/ExtraDry.Core/FilterSortPage/Collections/HierarchyCollection.cs
@@ -19,6 +19,12 @@ public class HierarchyCollection<T> : SortedCollection<T>
     public int MaxLevels { get; set; }
 
     /// <summary>
+    /// The minimum level of the hierarchy for the collection, ignoring any Level filter that may 
+    /// be applied.  
+    /// </summary>
+    public int MinLevels { get; set; }
+
+    /// <summary>
     /// The list of additional nodes, if any, that were expanded.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]

--- a/ExtraDry/ExtraDry.Server/Models/FilteredHierarchyQueryable.cs
+++ b/ExtraDry/ExtraDry.Server/Models/FilteredHierarchyQueryable.cs
@@ -108,12 +108,12 @@ public class FilteredHierarchyQueryable<T> : FilteredListQueryable<T> where T : 
     {
         return FilteredQuery
             .GroupBy(_ => 1, (_, records) =>
-                new Stats(records.Count(), records.Max(r => r.Lineage.GetLevel() + 1)));
+                new Stats(records.Count(), records.Max(r => r.Lineage.GetLevel() + 1), records.Min(r => r.Lineage.GetLevel() + 1)));
     }
 
     protected IQueryable<T> UnfilteredQuery { get; set; }
 
-    protected record Stats(int Total, int MaxLevels);
+    protected record Stats(int Total, int MaxLevels, int MinLevels);
 
     private new HierarchyQuery Query { get; }
 

--- a/ExtraDry/ExtraDry.Server/Models/PagedHierarchyQueryable.cs
+++ b/ExtraDry/ExtraDry.Server/Models/PagedHierarchyQueryable.cs
@@ -31,7 +31,7 @@ public class PagedHierarchyQueryable<T> : FilteredHierarchyQueryable<T> where T 
         var items = PagedQuery.ToList();
         var stats = statsQuery.Single();
         var children = childrenQuery.ToList();
-        return CreatePagedCollection(items, stats.Total, stats.MaxLevels, children);
+        return CreatePagedCollection(items, stats.Total, stats.MaxLevels, stats.MinLevels, children);
     }
 
     /// <inheritdoc cref="IFilteredQueryable{T}.ToPagedCollectionAsync(CancellationToken)" />
@@ -43,12 +43,12 @@ public class PagedHierarchyQueryable<T> : FilteredHierarchyQueryable<T> where T 
         var items = await ToListAsync(PagedQuery, cancellationToken);
         var stats = await ToSingleAsync(statsQuery, cancellationToken);
         var children = await ToListAsync(childrenQuery, cancellationToken);
-        return CreatePagedCollection(items, stats.Total, stats.MaxLevels, children);
+        return CreatePagedCollection(items, stats.Total, stats.MaxLevels, stats.MinLevels, children);
     }
 
     private new PageHierarchyQuery Query { get; }
 
-    private PagedHierarchyCollection<T> CreatePagedCollection(List<T> items, int total, int maxLevels, List<string> expandable)
+    private PagedHierarchyCollection<T> CreatePagedCollection(List<T> items, int total, int maxLevels, int minLevels, List<string> expandable)
     {
         var query = (Query as PageHierarchyQuery)!;
         var skip = query.Skip;
@@ -60,6 +60,7 @@ public class PagedHierarchyQueryable<T> : FilteredHierarchyQueryable<T> where T 
             Start = previousSkip,
             Total = total,
             MaxLevels = maxLevels,
+            MinLevels = minLevels,
             Level = query.Level,
             Expand = query.Expand.Any() ? query.Expand : null,
             Collapse = query.Collapse.Any() ? query.Collapse : null,

--- a/ExtraDry/Sample.Client/Pages/Components/Standard/ComboBoxComponentPage.razor.cs
+++ b/ExtraDry/Sample.Client/Pages/Components/Standard/ComboBoxComponentPage.razor.cs
@@ -174,6 +174,8 @@ public partial class ComboBoxComponentPage : ComponentBase, IListItemViewModel<S
 
         public int MaxLevel { get; set; }
 
+        public int MinLevel { get; set; }
+
         private List<Sector> Sectors { get; set; } = new();
 
         public async ValueTask<ItemsProviderResult<Sector>> GetItemsAsync(CancellationToken cancellationToken = default)


### PR DESCRIPTION
Hierarchy lists will now take note of the min level in cases where there is no level1 (Global/World view in the Regions example)
Before this PR, collapsing down to level 1 will through an argument out of range exception.

This works much the same way as MaxLevel in that it stops api calls from updating the level once it has reached it's Min/Max level