### PR TITLE
Initialise filter fields with existing filters

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryFilterEnumSelect.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryFilterEnumSelect.razor.cs
@@ -45,6 +45,10 @@ public partial class DryFilterEnumSelect : ComponentBase, IExtraDryComponent, ID
                 Filter = new EnumFilterBuilder { FilterName = Property.Property.Name };
                 PageQueryBuilder.Filters.Add(Filter);
             }
+            else {
+                //There is an existing filter, check if we need to sync the FilterSelect Values
+                SyncValues();
+            }
             EnumValues = Property.GetDiscreteValues();
             PageQueryBuilder.OnChanged += PageQueryBuilder_OnChanged;
         }
@@ -54,14 +58,24 @@ public partial class DryFilterEnumSelect : ComponentBase, IExtraDryComponent, ID
     {
         if(filterInSync && !FiltersMatchValues() && Values != null && Filter != null) {
             // component thinks filters in sync but they don't match, process incoming changes.
-            Values.Clear();
-            foreach(var value in Filter.Values) {
-                var vd = EnumValues.FirstOrDefault(e => e.Title == value);
-                if(vd != null) {
-                    Values.Add(vd);
-                }
+            SyncValues();
+        }
+    }
+
+    private void SyncValues()
+    {
+        if(Filter == null) { return; }
+        Values ??= new();
+        
+        Values.Clear();
+        foreach(var value in Filter.Values) {
+            var vd = EnumValues.FirstOrDefault(e => e.Title == value);
+            if(vd != null) {
+                Values.Add(vd);
             }
         }
+
+        StateHasChanged();
     }
 
     /// <summary>

--- a/ExtraDry/ExtraDry.Blazor/Models/ValueDescription.cs
+++ b/ExtraDry/ExtraDry.Blazor/Models/ValueDescription.cs
@@ -32,7 +32,13 @@ public class ValueDescription : ISubjectViewModel {
 
     public string Description => string.Empty;
 
-    public override bool Equals(object? obj) => (obj as ValueDescription)?.Key == Key;
+    public override bool Equals(object? obj)
+    {
+        if(obj == null) return false;
+        var otherKey = (obj as ValueDescription)?.Key;
+        if(otherKey == null) return false;
+        return otherKey.Equals(Key);
+    }
 
     public override int GetHashCode() => Key.GetHashCode();
 


### PR DESCRIPTION
If a  DryTable is created with an existing filter via adding a FilterBuilder to `QueryView.PageQueryBuilder.Filters`, the FilterSelect fields in `DryFilter` do not show these values. This PR makes them syncronise with existing filters.

![image](https://github.com/fmi-works/extra-dry/assets/444754/a43717e1-512c-4d58-81e9-6868c3dd0586)
