### PR TITLE
Perform a case insentive match for enum filter matching

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryFilterEnumSelect.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryFilterEnumSelect.razor.cs
@@ -69,7 +69,7 @@ public partial class DryFilterEnumSelect : ComponentBase, IExtraDryComponent, ID
         
         Values.Clear();
         foreach(var value in Filter.Values) {
-            var vd = EnumValues.FirstOrDefault(e => e.Title == value);
+            var vd = EnumValues.FirstOrDefault(e => string.Equals(e.Title, value, StringComparison.OrdinalIgnoreCase));
             if(vd != null) {
                 Values.Add(vd);
             }


### PR DESCRIPTION
When filters are passed via the URL, they are lowercase. This will ensure they still match the correct enum filter.