### PR TITLE
Use NullDisplayText for null values

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Internal/ViewModelTableRow.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Internal/ViewModelTableRow.razor
@@ -12,7 +12,7 @@
             break;
     }
     @foreach(var column in Description.TableProperties) {
-        var cssClass = column.DisplayClass;
+        var cssClass = column.ItemDisplayClass(Item.Item);
         var displayValue = column.DisplayValue(Item.Item);
         var hyperlink = Description.HyperLinkFor(column.Property.Name);
         if(column.HasDiscreteValues) {

--- a/ExtraDry/ExtraDry.Blazor/Models/PropertyDescription.cs
+++ b/ExtraDry/ExtraDry.Blazor/Models/PropertyDescription.cs
@@ -100,9 +100,9 @@ public class PropertyDescription {
             return string.Empty;
         }
         try {
-            var value = Property?.GetValue(item);
+            var value = Property?.GetValue(item); 
             if(value == null) {
-                return "null";
+                return Format?.NullDisplayText ?? "null";
             }
             if(HasDiscreteValues && discreteDisplayAttributes.TryGetValue((int)value, out var display)) {
                 value = display?.GetName() ?? value;
@@ -193,6 +193,18 @@ public class PropertyDescription {
             }
             return $"{typeClass} {Property.Name.ToLowerInvariant()}";
         }
+    }
+
+    public string ItemDisplayClass(object? item)
+    {
+        var typeClass = DisplayClass;
+        var value = Property?.GetValue(item);
+
+        if(value == null) {
+            typeClass = $"{typeClass} null";
+        }
+
+        return typeClass;
     }
 
     public bool HasDiscreteValues {


### PR DESCRIPTION
Allows a field to set it's own custom message for when it's value is null
![image](https://github.com/fmi-works/extra-dry/assets/444754/976a525a-65c6-467f-8916-f0bcea19ff2d)

Set the NullDisplayText value on the object model:
```
[DisplayFormat(ApplyFormatInEditMode = true, DataFormatString = "{0:dd/MM/yyyy}", NullDisplayText = "not set")]
public DateTime? ExpectedCompletion { get; set; }
```

Style the `.null` CSS class as required: 

```
.null {
    font-style: italic;
}
```