### PR TITLE
Client side model validation

### DIFF
--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryButton.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryButton.razor.cs
@@ -159,9 +159,7 @@ public partial class DryButton : ComponentBase, IExtraDryComponent {
         if(ResolvedCommand is null) {
             return;
         }
-        if(PreClickCheck != null) {
-            PreClickCheck.Invoke(ResolvedCommand.Context);
-        }
+        PreClickCheck?.Invoke(ResolvedCommand.Context);
         if(Model != null) {
             await ResolvedCommand.ExecuteAsync(Model);
         }

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/DryButton.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/DryButton.razor.cs
@@ -69,6 +69,12 @@ public partial class DryButton : ComponentBase, IExtraDryComponent {
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? UnmatchedAttributes { get; set; }
 
+    /// <summary>
+    /// A function that is called before the click action is executed. Used for pre-execution validation.
+    /// </summary>
+    [Parameter]
+    public Action<CommandContext>? PreClickCheck { get; set; }
+
     [CascadingParameter]
     protected SelectionSet? Selection { get; set; }
 
@@ -152,6 +158,9 @@ public partial class DryButton : ComponentBase, IExtraDryComponent {
     {
         if(ResolvedCommand is null) {
             return;
+        }
+        if(PreClickCheck != null) {
+            PreClickCheck.Invoke(ResolvedCommand.Context);
         }
         if(Model != null) {
             await ResolvedCommand.ExecuteAsync(Model);

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryFieldset.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryFieldset.razor
@@ -20,7 +20,7 @@
             @foreach(var line in group.Lines) {
                 <div class="line properties @redundant">
                     @foreach(var property in line.FormProperties) {
-                        <DryInput Model="@line.Model" Property="@property" />
+                        <DryInput Model="@line.Model" Property="@property" OnValidationChanged="@OnValidationChanged" />
                     }
                     @foreach(var command in line.Commands) {
                         if(command == Internal.FormCommand.AddNew) {

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryFieldset.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryFieldset.razor.cs
@@ -28,6 +28,13 @@ public partial class DryFieldset<T> : ComponentBase, IExtraDryComponent {
     [CascadingParameter]
     internal FormFieldset FormFieldset { get; set; } = null!;
 
+    /// <summary>
+    /// Event that is raised when the input is validated using internal rules. Does not check
+    /// global rules that might be set on the model using data annotations.
+    /// </summary>
+    [Parameter]
+    public EventCallback<ValidationEventArgs> OnValidationChanged { get; set; }
+
     private string CssClasses => DataConverter.JoinNonEmpty(" ", "dry-fieldset", Form.ModelNameSlug, FormFieldset.CssClass, CssClass);
 
     private CommandInfo AddNewCommand =>

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryForm.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryForm.razor
@@ -17,14 +17,14 @@
                 <div class="@ModelNameSlug fixed-fieldsets">
                     @foreach(var fieldset in FormDescription?.Fieldsets?.Take(FixedFieldsets) ?? Array.Empty<FormFieldset>()) {
                         <CascadingValue Value="@fieldset">
-                            <DryFieldset T="@T" />
+                            <DryFieldset T="@T" OnValidationChanged="@ValidationChanged" />
                         </CascadingValue>
                     }
                 </div>
                 <div class="@ModelNameSlug variable-fieldsets">
                     @foreach(var fieldset in FormDescription?.Fieldsets?.Skip(FixedFieldsets) ?? Array.Empty<FormFieldset>()) {
                         <CascadingValue Value="@fieldset">
-                            <DryFieldset T="@T" />
+                            <DryFieldset T="@T" OnValidationChanged="@ValidationChanged"/>
                         </CascadingValue>
                     }
                     <div class="content">
@@ -33,7 +33,7 @@
                 </div>
                 <ValidationBoundary>
                     <div class="@ModelNameSlug entity-actions">
-                        <DryButtonBar Commands="@Description?.Commands" Target="@Model" />
+                        <DryButtonBar Commands="@Description?.Commands" Target="@Model" PreClickCheck="@PreSubmissionCheck" />
                     </div>
                 </ValidationBoundary>
             }

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryForm.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryForm.razor.cs
@@ -1,4 +1,5 @@
 ﻿using ExtraDry.Blazor.Components.Internal;
+using ExtraDry.Core.Models;
 
 namespace ExtraDry.Blazor;
 
@@ -74,4 +75,71 @@ public partial class DryForm<T> : ComponentBase, IExtraDryComponent {
     private string CssClasses => DataConverter.JoinNonEmpty(" ", "dry-form", ModelNameSlug, CssClass);
 
     private List<string> AlertMessages { get; set; } = [];
+
+    private Task ValidationChanged(ValidationEventArgs validation)
+    {
+        // Validation event args only returns one validation error at a time, but we're ready for it to increase if it ever needs to.
+        // This also simplifies later logic.
+        if(validation.IsValid) {
+            ClientValidationErrors.Remove(validation.MemberName);
+        }
+        else {
+            if(ClientValidationErrors.ContainsKey(validation.MemberName)) {
+                ClientValidationErrors[validation.MemberName] = [validation.Message];
+            }
+            else {
+                ClientValidationErrors.Add(validation.MemberName, [validation.Message]);
+            }
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Persists a collection of client side validation errors, some of which model validation will not catch.
+    /// For example, inputting 31/02/2024 will not update the model becuase the 31st Feb doesn't exist, so cannot be stored in a DateTime object.
+    /// Values are a List to simplify the later logic with the model validator
+    /// </summary>
+    private Dictionary<string, List<string>> ClientValidationErrors { get; set; } = [];
+
+    private void PreSubmissionCheck(CommandContext context)
+    {
+        if(context == CommandContext.Alternate) {
+            // Only validate on Primary, Default or Danger calls.
+            return;
+        }
+        if(Model is null) {
+            // No point trying to validate something that doesn't exist.
+            return;
+        }
+
+        var validator = new DataValidator();
+        validator.ValidateObject(Model);
+        if(validator.Errors.Count == 0 && ClientValidationErrors.Count == 0) {
+            // Valid, continue.
+            return;
+        }
+
+        // Else, get union of model and UI validation issues and throw.
+        // TODO: Throw? Is it exceptional?
+
+        var union = new Dictionary<string, List<string>>(ClientValidationErrors);
+        foreach(var error in validator.Errors) {
+            foreach(var member in error.MemberNames) {
+                if(union.TryGetValue(member, out List<string>? messages)) {
+                    messages.Add(error.ErrorMessage ?? "Is Invalid");
+                } else {
+                    union.Add(member, [error.ErrorMessage ?? "Is Invalid"]);
+                }
+            }
+        }
+
+        var problem = new ProblemDetails() {
+            Title = "Some values are Invalid",
+            Status = 400,
+            Detail = "Client side validation"
+        };
+        problem.Extensions.Add("errors", union);
+
+        throw new DryException(problem);
+    }
 }

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryForm.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryForm.razor.cs
@@ -120,8 +120,6 @@ public partial class DryForm<T> : ComponentBase, IExtraDryComponent {
         }
 
         // Else, get union of model and UI validation issues and throw.
-        // TODO: Throw? Is it exceptional?
-
         var union = new Dictionary<string, List<string>>(ClientValidationErrors);
         foreach(var error in validator.Errors) {
             foreach(var member in error.MemberNames) {
@@ -134,11 +132,12 @@ public partial class DryForm<T> : ComponentBase, IExtraDryComponent {
         }
 
         var problem = new ProblemDetails() {
-            Title = "Some values are Invalid",
-            Status = 400,
+            Title = "One or more validation errors occurred.",
             Detail = "Client side validation"
         };
         problem.Extensions.Add("errors", union);
+        // Add a value to tell the validation that this is a client side validation error, not server side (which would have a 400 status)
+        problem.Extensions.Add("source", "client"); 
 
         throw new DryException(problem);
     }

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryInput.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryInput.razor.cs
@@ -186,8 +186,7 @@ public partial class DryInput<T>
     private async Task ValidationChanged(ValidationEventArgs validation)
     {
         UpdateValidationUI(validation.IsValid, validation.Message);
-        await OnValidationChanged.InvokeAsync(validation);
-        
+        await OnValidationChanged.InvokeAsync(validation);        
     }
 
     private void UpdateValidationUI(bool valid, string message)
@@ -197,5 +196,4 @@ public partial class DryInput<T>
         Valid = valid;
         StateHasChanged();
     }
-
 }

--- a/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryInput.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Dry/Forms/DryInput.razor.cs
@@ -37,6 +37,13 @@ public partial class DryInput<T>
     [Inject]
     private ILogger<DryInput<T>> Logger { get; set; } = null!;
 
+    /// <summary>
+    /// Event that is raised when the input is validated using internal rules. Does not check
+    /// global rules that might be set on the model using data annotations.
+    /// </summary>
+    [Parameter]
+    public EventCallback<ValidationEventArgs> OnValidationChanged { get; set; }
+
     protected async override Task OnInitializedAsync()
     {
         if(Property.Rules?.UpdateAction == RuleAction.Block) {
@@ -176,10 +183,11 @@ public partial class DryInput<T>
         }
     }
 
-    private Task ValidationChanged(ValidationEventArgs validation)
+    private async Task ValidationChanged(ValidationEventArgs validation)
     {
         UpdateValidationUI(validation.IsValid, validation.Message);
-        return Task.CompletedTask;
+        await OnValidationChanged.InvokeAsync(validation);
+        
     }
 
     private void UpdateValidationUI(bool valid, string message)

--- a/ExtraDry/ExtraDry.Blazor/Components/DryButtonBar.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/DryButtonBar.razor
@@ -7,7 +7,7 @@
             var className = context.ToString().ToLowerInvariant();
             <div class="@className">
                 @foreach(var command in commands) { 
-                    <DryButton Command="@command" Model="@Target" />
+                    <DryButton Command="@command" Model="@Target" PreClickCheck="@PreClickCheck" />
                 }
             </div>
         }

--- a/ExtraDry/ExtraDry.Blazor/Components/DryButtonBar.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/DryButtonBar.razor.cs
@@ -26,6 +26,12 @@ public partial class DryButtonBar : ComponentBase {
     [Parameter]
     public string? Category { get; set; }
 
+    /// <summary>
+    /// A function that is called before the click action of a button is executed. Used for pre-execution validation.
+    /// </summary>
+    [Parameter]
+    public Action<CommandContext>? PreClickCheck { get; set; }
+
     private ViewModelDescription? Description { get; set; }
 
     protected override void OnParametersSet()
@@ -39,5 +45,4 @@ public partial class DryButtonBar : ComponentBase {
     private IEnumerable<CommandInfo> SelectCommands(CommandContext context) => Commands
         .Where(e => e.Context == context)
         .Where(e => Category == null || Category == e.Category);
-
 }

--- a/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationBoundary.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationBoundary.razor
@@ -23,4 +23,3 @@
         }
     </ErrorContent>
 </ExposedErrorBoundary>
-

--- a/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationBoundary.razor
+++ b/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationBoundary.razor
@@ -23,3 +23,4 @@
         }
     </ErrorContent>
 </ExposedErrorBoundary>
+

--- a/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationSummary.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationSummary.razor.cs
@@ -41,10 +41,11 @@ public partial class ValidationSummary : ComponentBase, IExtraDryComponent
         }
 
         var alertMessages = new List<string>();
-        if(errors is not JsonElement) {
+        var clientSideErrors = errors is Dictionary<string, List<string>>;
+        if(errors is not JsonElement && !clientSideErrors) {
             return [];
         }
-        var messages = JsonSerializer.Deserialize<Dictionary<string, List<string>>>(errors.ToString() ?? string.Empty);
+        var messages = clientSideErrors ? errors as Dictionary<string, List<string>> : JsonSerializer.Deserialize<Dictionary<string, List<string>>>(errors.ToString() ?? string.Empty);
         if(messages == null || messages.Keys.Count == 0) {
             return [];
         }

--- a/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationSummary.razor.cs
+++ b/ExtraDry/ExtraDry.Blazor/Components/Special/ValidationSummary.razor.cs
@@ -90,7 +90,18 @@ public partial class ValidationSummary : ComponentBase, IExtraDryComponent
 
     private string CssClasses => DataConverter.JoinNonEmpty(" ", "validation-summary", ErrorCss, CssClass);
 
-    private string ErrorCss => IsValidationError ? $"status{ProblemDetails!.Status}": "unexpected-error";
+    private string ErrorCss => IsValidationError ? $"status{ProblemDetails!.Status}" : "unexpected-error";
 
-    private bool IsValidationError => ProblemDetails != null && ProblemDetails.Status == (int)HttpStatusCode.BadRequest;
+    private bool IsValidationError {
+        get {
+            if(ProblemDetails is null) {
+                return false;
+            }
+            if(ProblemDetails.Status == (int)HttpStatusCode.BadRequest) {
+                return true;
+            }
+            ProblemDetails.Extensions.TryGetValue("source", out var source);
+            return source != null && source.ToString() == "client";
+        }
+    }
 }


### PR DESCRIPTION
Adds functionality to validate the model on a form before submission.
In order to do this, we hook into the individual inputs OnValidation to bubble any client side validation errors up to the form, this allows us to track any validation errors that don't make it to the model. An example of this is an invalid date format on a date input, this value never makes it to the model, so can't be validated.

We now also pass a preflight check (Pre-Click) check func through from the form, through the button bar to the buttons to execute before their click event. In this check we compile a union of the validation errors and throw a DryException if invalid. This takes advantage of the existing validation boundaries for display.